### PR TITLE
Fix focus binding

### DIFF
--- a/src/cpp/core.cpp
+++ b/src/cpp/core.cpp
@@ -61,7 +61,7 @@ PYBIND11_MODULE(polyscope_bindings, m) {
   m.def("set_enable_render_error_checks", [](bool x) { ps::options::enableRenderErrorChecks = x; });
   m.def("set_autocenter_structures", [](bool x) { ps::options::autocenterStructures = x; });
   m.def("set_autoscale_structures", [](bool x) { ps::options::autoscaleStructures = x; });
-  m.def("give_focus_on_show", [](bool x) { ps::options::giveFocusOnShow = x; });
+  m.def("set_give_focus_on_show", [](bool x) { ps::options::giveFocusOnShow = x; });
   m.def("set_navigation_style", [](ps::view::NavigateStyle x) { ps::view::style = x; });
   m.def("set_up_dir", [](ps::view::UpDir x) { ps::view::setUpDir(x); });
 

--- a/src/polyscope/core.py
+++ b/src/polyscope/core.py
@@ -74,8 +74,8 @@ def set_autocenter_structures(b):
 def set_autoscale_structures(b):
     psb.set_autoscale_structures(b)
 
-def give_focus_on_show(b):
-    psb.give_focus_on_show(b)
+def set_give_focus_on_show(b):
+    psb.set_give_focus_on_show(b)
 
 def set_navigation_style(s):
     psb.set_navigation_style(str_to_navigate_style(s))


### PR DESCRIPTION
I realized that to be consistent with other bindings of Boolean options, I should at a `set_` prefix to the method name.  I also bumped the reference of the Polyscope dependency to point to current master