### PR TITLE
Add Pick Methods

### DIFF
--- a/src/cpp/core.cpp
+++ b/src/cpp/core.cpp
@@ -7,9 +7,14 @@
 #include "Eigen/Dense"
 
 #include "polyscope/affine_remapper.h"
+#include "polyscope/curve_network.h"
+#include "polyscope/pick.h"
+#include "polyscope/point_cloud.h"
 #include "polyscope/polyscope.h"
+#include "polyscope/surface_mesh.h"
 #include "polyscope/surface_parameterization_enums.h"
 #include "polyscope/view.h"
+#include "polyscope/volume_mesh.h"
 
 namespace py = pybind11;
 namespace ps = polyscope;

--- a/src/cpp/core.cpp
+++ b/src/cpp/core.cpp
@@ -134,7 +134,37 @@ PYBIND11_MODULE(polyscope_bindings, m) {
       ps::state::userCallback = wrapperFunc;
   });
   m.def("clear_user_callback", []() {ps::state::userCallback = nullptr;});
-  
+
+  // === Pick
+  m.def("have_selection", [](){ return ps::pick::haveSelection();});
+  m.def("get_selection", [](){
+    const auto selection = ps::pick::getSelection();
+    const auto * structure = std::get<0>(selection);
+    if (structure == nullptr) {
+      return std::make_tuple(std::string(), size_t{0});
+    }
+    return std::make_tuple(structure->name, std::get<1>(selection));
+  });
+  m.def(
+    "set_selection",
+    [](const std::string &name, size_t index){
+      for(const auto &structureTypeName : std::array<std::string, 4>{
+        ps::PointCloud::structureTypeName,
+        ps::CurveNetwork::structureTypeName,
+        ps::SurfaceMesh::structureTypeName,
+        ps::VolumeMesh::structureTypeName
+      }) {
+        if (ps::hasStructure(structureTypeName, name)) {
+          auto * structure = ps::getStructure(structureTypeName, name);
+          ps::pick::setSelection(std::make_pair(structure, index));
+          break;
+        }
+      }
+    },
+    py::arg("name"),
+    py::arg("index")
+  );
+
   // === Ground plane and shadows
   m.def("set_ground_plane_mode", [](ps::GroundPlaneMode x) { ps::options::groundPlaneMode = x; });
   m.def("set_ground_plane_height_factor", [](float x, bool isRelative) { ps::options::groundPlaneHeightFactor.set(x, isRelative); });
@@ -156,7 +186,6 @@ PYBIND11_MODULE(polyscope_bindings, m) {
   m.def("load_color_map", ps::loadColorMap, "Load a color map from file");
   
   // === Rendering
-  m.def("load_color_map", ps::loadColorMap, "Load a color map from file");
   m.def("set_SSAA_factor", [](int n) { ps::options::ssaaFactor = n; });
 
   // === Slice planes

--- a/src/cpp/surface_mesh.cpp
+++ b/src/cpp/surface_mesh.cpp
@@ -65,7 +65,7 @@ void bind_surface_mesh(py::module& m) {
       .def("update_vertex_positions2D", &ps::SurfaceMesh::updateVertexPositions2D<Eigen::MatrixXd>,
            "Update vertex positions")
       .def("n_vertices", &ps::SurfaceMesh::nVertices, "# vertices")
-      .def("n_faces", &ps::SurfaceMesh::nFaces, "# edges")
+      .def("n_faces", &ps::SurfaceMesh::nFaces, "# faces")
       .def("n_edges", &ps::SurfaceMesh::nEdges, "# edges")
       .def("n_corners", &ps::SurfaceMesh::nCorners, "# corners")
       .def("n_halfedges", &ps::SurfaceMesh::nHalfedges, "# halfedges")
@@ -91,7 +91,7 @@ void bind_surface_mesh(py::module& m) {
       .def("get_ignore_slice_plane", &ps::SurfaceMesh::getIgnoreSlicePlane, "Get ignore slice plane")
       .def("set_cull_whole_elements", &ps::SurfaceMesh::setCullWholeElements, "Set cull whole elements")
       .def("get_cull_whole_elements", &ps::SurfaceMesh::getCullWholeElements, "Get cull whole elements")
-     
+
 
       // permutations & bases
       .def("set_vertex_permutation", &ps::SurfaceMesh::setVertexPermutation<Eigen::VectorXi>, "Set vertex permutation")

--- a/src/polyscope/core.py
+++ b/src/polyscope/core.py
@@ -147,6 +147,16 @@ def set_user_callback(func):
 def clear_user_callback():
     psb.clear_user_callback()
 
+### Pick
+def have_selection():
+    return psb.have_selection()
+
+def get_selection():
+    return psb.get_selection()
+
+def set_selection(name, index):
+    psb.set_selection(name, index)
+
 ## Ground plane and shadows
 def set_ground_plane_mode(mode_str):
     psb.set_ground_plane_mode(str_to_ground_plane_mode(mode_str))


### PR DESCRIPTION
Add pick methods to set of bindings
* `have_selection()` - returns if there is a selection
* `get_selection()` - returns a `(str, int)` tuple, representing current selection. If no selection, returns `("", 0)`.
* `set_selection()` - sets the current selected structure by name and index

When building UI interactions, it's useful to be able to set the pick selection based on events outside the pick routine.  The C++ functions take a `Structure*` but the `Structure` class doesn't have a binding, so pybind11 can't auto-convert something like a `SurfaceMesh` to a `Structure`, so I made the interface using the structure names.  There are other ways to implement this, but it seemed like a simple enough interface to do it this way.