### PR TITLE
Add exception to register functions if polyscope is not initialized

### DIFF
--- a/src/cpp/core.cpp
+++ b/src/cpp/core.cpp
@@ -58,6 +58,8 @@ PYBIND11_MODULE(polyscope_bindings, m) {
   
   // === Basic flow 
   m.def("init", &ps::init, py::arg("backend")="", "Initialize Polyscope");
+  m.def("checkInitialized", &ps::checkInitialized);
+  m.def("isInitialized", &ps::isInitialized);
   m.def("show", [](size_t forFrames) {
         if (ps::state::userCallback == nullptr) {
           bool oldVal = ps::options::openImGuiWindowForUserCallback;

--- a/src/cpp/imgui.cpp
+++ b/src/cpp/imgui.cpp
@@ -1595,8 +1595,6 @@ void bind_imgui_enums(py::module& m) {
   m.attr("ImGuiInputTextFlags_NoUndoRedo") = static_cast<int>(ImGuiInputTextFlags_NoUndoRedo);
   m.attr("ImGuiInputTextFlags_CharsScientific") = static_cast<int>(ImGuiInputTextFlags_CharsScientific);
   m.attr("ImGuiInputTextFlags_CallbackResize") = static_cast<int>(ImGuiInputTextFlags_CallbackResize);
-  m.attr("ImGuiInputTextFlags_Multiline") = static_cast<int>(ImGuiInputTextFlags_Multiline);
-  m.attr("ImGuiInputTextFlags_NoMarkEdited") = static_cast<int>(ImGuiInputTextFlags_NoMarkEdited);
 
   m.attr("ImGuiTreeNodeFlags_None") = static_cast<int>(ImGuiTreeNodeFlags_None);
   m.attr("ImGuiTreeNodeFlags_Selected") = static_cast<int>(ImGuiTreeNodeFlags_Selected);
@@ -1747,13 +1745,6 @@ void bind_imgui_enums(py::module& m) {
   m.attr("ImGuiNavInput_FocusNext") = static_cast<int>(ImGuiNavInput_FocusNext);
   m.attr("ImGuiNavInput_TweakSlow") = static_cast<int>(ImGuiNavInput_TweakSlow);
   m.attr("ImGuiNavInput_TweakFast") = static_cast<int>(ImGuiNavInput_TweakFast);
-  m.attr("ImGuiNavInput_KeyMenu_") = static_cast<int>(ImGuiNavInput_KeyMenu_);
-  m.attr("ImGuiNavInput_KeyLeft_") = static_cast<int>(ImGuiNavInput_KeyLeft_);
-  m.attr("ImGuiNavInput_KeyRight_") = static_cast<int>(ImGuiNavInput_KeyRight_);
-  m.attr("ImGuiNavInput_KeyUp_") = static_cast<int>(ImGuiNavInput_KeyUp_);
-  m.attr("ImGuiNavInput_KeyDown_") = static_cast<int>(ImGuiNavInput_KeyDown_);
-  m.attr("ImGuiNavInput_COUNT") = static_cast<int>(ImGuiNavInput_COUNT);
-  m.attr("ImGuiNavInput_InternalStart_") = static_cast<int>(ImGuiNavInput_InternalStart_);
 
   m.attr("ImGuiConfigFlags_None") = static_cast<int>(ImGuiConfigFlags_None);
   m.attr("ImGuiConfigFlags_NavEnableKeyboard") = static_cast<int>(ImGuiConfigFlags_NavEnableKeyboard);
@@ -1870,11 +1861,6 @@ void bind_imgui_enums(py::module& m) {
   m.attr("ImGuiColorEditFlags_PickerHueWheel") = static_cast<int>(ImGuiColorEditFlags_PickerHueWheel);
   m.attr("ImGuiColorEditFlags_InputRGB") = static_cast<int>(ImGuiColorEditFlags_InputRGB);
   m.attr("ImGuiColorEditFlags_InputHSV") = static_cast<int>(ImGuiColorEditFlags_InputHSV);
-  m.attr("ImGuiColorEditFlags__OptionsDefault") = static_cast<int>(ImGuiColorEditFlags__OptionsDefault);
-  m.attr("ImGuiColorEditFlags__DisplayMask") = static_cast<int>(ImGuiColorEditFlags__DisplayMask);
-  m.attr("ImGuiColorEditFlags__DataTypeMask") = static_cast<int>(ImGuiColorEditFlags__DataTypeMask);
-  m.attr("ImGuiColorEditFlags__PickerMask") = static_cast<int>(ImGuiColorEditFlags__PickerMask);
-  m.attr("ImGuiColorEditFlags__InputMask") = static_cast<int>(ImGuiColorEditFlags__InputMask);
 
   m.attr("ImGuiMouseButton_Left") = static_cast<int>(ImGuiMouseButton_Left);
   m.attr("ImGuiMouseButton_Right") = static_cast<int>(ImGuiMouseButton_Right);

--- a/src/polyscope/curve_network.py
+++ b/src/polyscope/curve_network.py
@@ -228,7 +228,9 @@ class CurveNetwork:
 
 def register_curve_network(name, nodes, edges, enabled=None, radius=None, color=None, material=None, transparency=None):
     """Register a new curve network"""
-
+    if not psb.isInitialized():
+        raise RuntimeError("Polyscope has not been initialized")
+    
     p = CurveNetwork(name, nodes, edges)
 
     # == Apply options

--- a/src/polyscope/point_cloud.py
+++ b/src/polyscope/point_cloud.py
@@ -190,6 +190,8 @@ class PointCloud:
 
 def register_point_cloud(name, points, enabled=None, radius=None, point_render_mode=None, color=None, material=None, transparency=None):
     """Register a new point cloud"""
+    if not psb.isInitialized():
+        raise RuntimeError("Polyscope has not been initialized")
 
     p = PointCloud(name, points)
 

--- a/src/polyscope/surface_mesh.py
+++ b/src/polyscope/surface_mesh.py
@@ -440,6 +440,9 @@ def register_surface_mesh(name, vertices, faces, enabled=None, color=None, edge_
                           edge_width=None, material=None, back_face_policy=None, back_face_color=None, transparency=None):
     """Register a new surface mesh"""
 
+    if not psb.isInitialized():
+        raise RuntimeError("Polyscope has not been initialized")
+    
     p = SurfaceMesh(name, vertices, faces)
 
     # == Apply options

--- a/src/polyscope/volume_mesh.py
+++ b/src/polyscope/volume_mesh.py
@@ -242,7 +242,9 @@ class VolumeMesh:
 def register_volume_mesh(name, vertices, tets=None, hexes=None, mixed_cells=None, enabled=None, color=None, interior_color=None, edge_color=None, edge_width=None, material=None, transparency=None):
 
     """Register a new surface mesh"""
-
+    if not psb.isInitialized():
+        raise RuntimeError("Polyscope has not been initialized")
+    
     p = VolumeMesh(name, vertices=vertices, tets=tets, hexes=hexes, mixed_cells=mixed_cells)
 
     # == Apply options

--- a/test/polyscope_demo.py
+++ b/test/polyscope_demo.py
@@ -26,6 +26,10 @@ def main():
 
     # Build arguments
     parser.add_argument('mesh', type=str, help='path to a mesh')
+    parser.add_argument('--surfacemesh', default=True, action='store_true')
+    parser.add_argument('--no-surfacemesh', dest='surfacemesh', action='store_false')
+    parser.add_argument('--pointcloud', default=False, action='store_true')
+    parser.add_argument('--volumemesh', default=False, action='store_true')
 
     # Parse arguments
     args = parser.parse_args()
@@ -53,7 +57,7 @@ def main():
     polyscope.set_ground_plane_mode("shadow_only")
 
     ## Examples with a mesh
-    if True:
+    if args.surfacemesh:
         ps_mesh = polyscope.register_surface_mesh("test mesh", verts, faces, enabled=True)
 
         # Scalar functions
@@ -76,7 +80,7 @@ def main():
 
 
     ## Examples with a point cloud
-    if False:
+    if args.pointcloud:
         ps_points = polyscope.register_point_cloud("test points", verts, point_render_mode='sphere')
 
         # Scalar functions
@@ -110,7 +114,7 @@ def main():
 
 
     # Volume mesh examples
-    if False:
+    if args.volumemesh:
         verts = np.array([
             [0, 0, 0],
             [1, 0, 0],


### PR DESCRIPTION
- Previously if a register function was called and polyscope was not initialized you would get a seg fault. Adding this check now gives you a useful exception that tells you that polyscope needs to be initialized.
- Made some changes to imgui.cpp for compatibility with the latest version 1.88