### PR TITLE
Correctly reshape generate_camera_rays output

### DIFF
--- a/src/polyscope/core.py
+++ b/src/polyscope/core.py
@@ -466,7 +466,7 @@ class CameraParameters:
                 int(dims[0]), int(dims[1]),
                 str_to_image_origin(image_origin)
             )
-        return out_rays.reshape(dims[0], dims[1], 3)
+        return out_rays.reshape(dims[1], dims[0], 3).transpose((1,0,2))
 
     def generate_camera_ray_corners(self): 
         return self.instance.generate_camera_ray_corners()

--- a/src/polyscope/core.py
+++ b/src/polyscope/core.py
@@ -463,10 +463,10 @@ class CameraParameters:
 
     def generate_camera_rays(self, dims, image_origin='upper_left'): 
         out_rays = self.instance.generate_camera_rays(
-                int(dims[0]), int(dims[1]),
+                int(dims[1]), int(dims[0]),
                 str_to_image_origin(image_origin)
             )
-        return out_rays.reshape(dims[1], dims[0], 3).transpose((1,0,2))
+        return out_rays.reshape(dims[0], dims[1], 3)
 
     def generate_camera_ray_corners(self): 
         return self.instance.generate_camera_ray_corners()

--- a/src/polyscope/core.py
+++ b/src/polyscope/core.py
@@ -463,10 +463,10 @@ class CameraParameters:
 
     def generate_camera_rays(self, dims, image_origin='upper_left'): 
         out_rays = self.instance.generate_camera_rays(
-                int(dims[1]), int(dims[0]),
+                int(dims[0]), int(dims[1]),
                 str_to_image_origin(image_origin)
             )
-        return out_rays.reshape(dims[0], dims[1], 3)
+        return out_rays.reshape(dims[1], dims[0], 3)
 
     def generate_camera_ray_corners(self): 
         return self.instance.generate_camera_ray_corners()

--- a/test/polyscope_test.py
+++ b/test/polyscope_test.py
@@ -1997,9 +1997,11 @@ class TestCameraView(unittest.TestCase):
 
         self.assertTrue(isinstance(params.get_fov_vertical_deg(), float))
         self.assertTrue(isinstance(params.get_aspect(), float))
-        
-        rays = params.generate_camera_rays((300,200))
-        assertArrayWithShape(self, rays, [300,200,3])
+       
+        dimX = 300
+        dimY = 200
+        rays = params.generate_camera_rays((dimX,dimY))
+        assertArrayWithShape(self, rays, [dimY,dimX,3])
         ray_corners = params.generate_camera_ray_corners()
     
     def test_floating_scalar_images(self):

--- a/test/polyscope_test.py
+++ b/test/polyscope_test.py
@@ -1999,6 +1999,7 @@ class TestCameraView(unittest.TestCase):
         self.assertTrue(isinstance(params.get_aspect(), float))
         
         rays = params.generate_camera_rays((300,200))
+        assertArrayWithShape(self, rays, [300,200,3])
         ray_corners = params.generate_camera_ray_corners()
     
     def test_floating_scalar_images(self):


### PR DESCRIPTION
In the C++ implementation of `CameraParameters::generateCameraRays`, the ray directions are stored in a flattened array, written in a nested loop over `dimY` then `dimX`. However, this makes the image-conforming shape of the output array `[dimY,dimX,3]`, which makes the current implementation incorrect unless `dimY == dimX`. This PR produces a correct image-conforming array of ray directions.