### PR TITLE
Update CI adding ARM

### DIFF
--- a/.github/workflows/cibuildwheel_config.toml
+++ b/.github/workflows/cibuildwheel_config.toml
@@ -19,6 +19,3 @@ CMAKE_ARGS = "DPOLYSCOPE_BACKEND_OPENGL3_EGL=ON"
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
 before-all = "apk add libx11-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev freeglut-dev mesa-dev mesa-gl mesa-egl"
-
-manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64"
-manylinux-aarch64-image = "quay.io/pypa/manylinux_2_28_aarch64"

--- a/.github/workflows/cibuildwheel_config.toml
+++ b/.github/workflows/cibuildwheel_config.toml
@@ -1,11 +1,11 @@
 [tool.cibuildwheel]
-skip = "cp36-*" # scikit-build-core requires >=3.7
+skip = "cp36-*" # scikit-build-core requires >=3.9
 build-verbosity = 3
 
 [tool.cibuildwheel.linux]
 before-all = [
     "yum remove -y cmake",
-    "yum install -y libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel mesa-libGL-devel mesa-libGL libXi-devel freeglut-devel mesa-libEGL-devel"
+    "yum install -y llvm-devel clang-devel eigen3 eigen3-devel libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel mesa-libGL-devel mesa-libGL libXi-devel freeglut-devel mesa-libEGL-devel"
 ]
 # Tell auditwheel _not_ to bundle libEGL, as it is platform/driver specific won't work (segfaults). We need to use the system libEGL.
 # Fortunately almost all linux systems should have this, but might cause linking errors at runtime if not
@@ -18,4 +18,7 @@ CMAKE_ARGS = "DPOLYSCOPE_BACKEND_OPENGL3_EGL=ON"
 # musllinux builds on an Alpinx Linux image, need different package names
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
-before-all = "apk add libx11-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev freeglut-dev mesa-dev mesa-gl mesa-egl"
+before-all = "gcc g++ libeigen3-dev apk add libx11-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev freeglut-dev mesa-dev mesa-gl mesa-egl"
+
+manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64"
+manylinux-aarch64-image = "quay.io/pypa/manylinux_2_28_aarch64"

--- a/.github/workflows/cibuildwheel_config.toml
+++ b/.github/workflows/cibuildwheel_config.toml
@@ -1,5 +1,5 @@
 [tool.cibuildwheel]
-skip = "cp36-*" # scikit-build-core requires >=3.6
+skip = "cp36-*" # scikit-build-core requires >=3.7
 build-verbosity = 3
 
 [tool.cibuildwheel.linux]

--- a/.github/workflows/cibuildwheel_config.toml
+++ b/.github/workflows/cibuildwheel_config.toml
@@ -1,11 +1,11 @@
 [tool.cibuildwheel]
-skip = "cp36-*" # scikit-build-core requires >=3.9
+skip = "cp36-*" # scikit-build-core requires >=3.6
 build-verbosity = 3
 
 [tool.cibuildwheel.linux]
 before-all = [
     "yum remove -y cmake",
-    "yum install -y llvm-devel clang-devel eigen3 eigen3-devel libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel mesa-libGL-devel mesa-libGL libXi-devel freeglut-devel mesa-libEGL-devel"
+    "yum install -y libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel mesa-libGL-devel mesa-libGL libXi-devel freeglut-devel mesa-libEGL-devel"
 ]
 # Tell auditwheel _not_ to bundle libEGL, as it is platform/driver specific won't work (segfaults). We need to use the system libEGL.
 # Fortunately almost all linux systems should have this, but might cause linking errors at runtime if not
@@ -18,7 +18,7 @@ CMAKE_ARGS = "DPOLYSCOPE_BACKEND_OPENGL3_EGL=ON"
 # musllinux builds on an Alpinx Linux image, need different package names
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
-before-all = "gcc g++ libeigen3-dev apk add libx11-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev freeglut-dev mesa-dev mesa-gl mesa-egl"
+before-all = "apk add libx11-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev freeglut-dev mesa-dev mesa-gl mesa-egl"
 
 manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64"
 manylinux-aarch64-image = "quay.io/pypa/manylinux_2_28_aarch64"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-latest]
 
     name: Build wheels ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -34,10 +34,10 @@ jobs:
           python -m build --sdist
 
       - name: Run cibuildwheel
-        uses: pypa/cibuildwheel@v2.21 
+        uses: pypa/cibuildwheel@v2.23.2
         with:
           config-file: ".github/workflows/cibuildwheel_config.toml"
-      
+
       - name: Copy source distribution into wheelhouse
         if: runner.os == 'Linux'
         run: mv dist/*.tar.gz wheelhouse/
@@ -46,10 +46,10 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: |
             ./wheelhouse/*.whl 
-            ./wheelhouse/*.tar.gz 
+            ./wheelhouse/*.tar.gz
           overwrite: true
 
   # Push the resulting binaries to pypi on a tag starting with 'v'
@@ -68,7 +68,7 @@ jobs:
       id-token: write
     steps:
       - name: Download built wheels artifact # downloads from the jobs storage from the previous step
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.2.1
         with:
           # omitting the `name: ` field downloads all artifacts from this workflow
           path: dist
@@ -77,10 +77,10 @@ jobs:
         run: ls dist | cat  # piping through cat prints one per line
 
         # dist directory has subdirs from the different jobs, merge them into one directory and delete
-        # the empty leftover dirs 
-      - name: Flatten directory 
+        # the empty leftover dirs
+      - name: Flatten directory
         run: find dist -mindepth 2 -type f -exec mv -t dist {} + && find dist -type d -empty -delete
-      
+
       - name: List downloaded files from artifact after flatten
         run: ls dist | cat  # piping through cat prints one per line
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        # macos-13 is an intel runner, macos-14 is apple silicon
+        # macos-13 is an intel runner, macos-14+ is apple silicon
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-latest]
 
     name: Build wheels ${{ matrix.os }}

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-13 is an intel runner, macos-14 is apple silicon
+        # macos-13 is an intel runner, macos-14+ is apple silicon
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-latest]
 
     name: Build wheels ${{ matrix.os }}

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,3 +1,4 @@
+
 name: Test Build
 
 # NOTE: build logic is duplicated here and in publish.yml
@@ -21,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-latest]
 
     name: Build wheels ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -38,7 +39,7 @@ jobs:
           python -m build --sdist
 
       - name: Run cibuildwheel
-        uses: pypa/cibuildwheel@v2.21
+        uses: pypa/cibuildwheel@v2.23.2
         with:
           config-file: ".github/workflows/cibuildwheel_config.toml"
 
@@ -46,7 +47,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: |
             ./wheelhouse/*.whl 
             ./wheelhouse/*.tar.gz 

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -8,32 +8,48 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Only run if the commit message contains '[ci build]'
     if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
+    name: Build wheels - ${{ matrix.os }}-${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: x64
+          - os: ubuntu-24.04-arm
+            arch: aarch64
+
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
-      
-    - uses: actions/setup-python@v2
+
+    - uses: actions/setup-python@v5
       name: Install Python
       with:
-        python-version: '3.9'
+        python-version: '3.12'
 
     - name: install packages
-      run: sudo apt-get update && sudo apt-get install -y xorg-dev libglu1-mesa-dev xpra xserver-xorg-video-dummy freeglut3-dev
-    
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc g++ libeigen3-dev xorg-dev libglu1-mesa-dev xpra xserver-xorg-video-dummy freeglut3-dev
+
     - name: install python packages
       run: python3 -m pip install numpy
 
     - name: configure
-      run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)") -DPOLYSCOPE_BACKEND_OPENGL3_EGL=ON ..
+      run: |
+        mkdir build
+        cd build
+        cmake -DCMAKE_BUILD_TYPE=Debug -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)") -DPOLYSCOPE_BACKEND_OPENGL3_EGL=ON ..
 
     - name: build
       run: cd build && make
 
     - name: run test backend mock
       run: python3 test/polyscope_test.py -v
-    
+
     - name: run test backend EGL
       run: python3 test/polyscope_test.py -v backend=openGL3_egl

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    # Only run if the commit message contains '[ci build]'
+    # Skip running if the commit message contains '[ci skip]'
     if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
     name: Build wheels - ${{ matrix.os }}-${{ matrix.arch }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -32,9 +32,7 @@ jobs:
         python-version: '3.12'
 
     - name: install packages
-      run: |
-        sudo apt-get update
-        run: sudo apt-get update && sudo apt-get install -y xorg-dev libglu1-mesa-dev xpra xserver-xorg-video-dummy freeglut3-dev
+      run: sudo apt-get update && sudo apt-get install -y xorg-dev libglu1-mesa-dev xpra xserver-xorg-video-dummy freeglut3-dev
 
     - name: install python packages
       run: python3 -m pip install numpy

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -34,7 +34,7 @@ jobs:
     - name: install packages
       run: |
         sudo apt-get update
-        sudo apt-get install -y gcc g++ libeigen3-dev xorg-dev libglu1-mesa-dev xpra xserver-xorg-video-dummy freeglut3-dev
+        run: sudo apt-get update && sudo apt-get install -y xorg-dev libglu1-mesa-dev xpra xserver-xorg-video-dummy freeglut3-dev
 
     - name: install python packages
       run: python3 -m pip install numpy

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -33,14 +33,6 @@ jobs:
     - name: install python packages
       run: python -m pip install numpy
 
-    - name: install packages
-      run: |
-          brew install eigen
-          brew install glfw
-          brew install freeglut
-          brew install xorg-server
-          brew install xpra
-
     - name: configure
       run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DPOLYSCOPE_BACKEND_OPENGL3_GLFW=ON -DPOLYSCOPE_BACKEND_OPENGL_MOCK=ON ..
 

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    # Only run if the commit message contains '[ci build]'
+    # Skip running if the commit message contains '[ci skip]'
     if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
     name: Build wheels - ${{ matrix.os }}-${{ matrix.arch }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -8,20 +8,38 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    # Only run if the commit message contains '[ci build]'
     if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
+    name: Build wheels - ${{ matrix.os }}-${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-13
+            arch: x64
+          - os: macos-latest
+            arch: arm64
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v5
       name: Install Python
       with:
-        python-version: '3.9'
+        python-version: '3.12'
 
     - name: install python packages
       run: python -m pip install numpy
+
+    - name: install packages
+      run: |
+          brew install eigen
+          brew install glfw
+          brew install freeglut
+          brew install xorg-server
+          brew install xpra
 
     - name: configure
       run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DPOLYSCOPE_BACKEND_OPENGL3_GLFW=ON -DPOLYSCOPE_BACKEND_OPENGL_MOCK=ON ..

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -23,10 +23,6 @@ jobs:
     - name: install python packages
       run: python -m pip install numpy
 
-    - name: install packages
-      run: |
-        choco install -y eigen
-
     - name: configure
       run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug ..
 

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    # Skip running if the commit message contains '[ci skip]'
     if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -11,17 +11,21 @@ jobs:
     runs-on: windows-latest
     if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v5
       name: Install Python
       with:
-        python-version: '3.7'
+        python-version: '3.12'
     
     - name: install python packages
       run: python -m pip install numpy
+
+    - name: install packages
+      run: |
+        choco install -y eigen
 
     - name: configure
       run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug ..

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -8,9 +8,20 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
     # Skip running if the commit message contains '[ci skip]'
     if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
+    name: Build wheels - ${{ matrix.os }}-${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            arch: x64
+          # Windows ARM is not available as of Mar 2025, but coming soon: https://github.com/github/roadmap/issues/1098
+
+
+
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/
This pull request includes several updates to the CI workflows, build configurations, and dependencies. The primary focus is on enhancing compatibility, updating dependencies, and improving the build process across different operating systems.

### CI Workflow and Build Configuration Updates:

* [`.github/workflows/cibuildwheel_config.toml`](diffhunk://#diff-cffeae69f692d4ec4ce12998a1dfc490b601658b93de49671b2f66f264f81a13L2-R8): Updated to skip Python versions 3.7 and 3.8, added new dependencies for Linux builds, and specified new manylinux images for x86_64 and aarch64. [[1]](diffhunk://#diff-cffeae69f692d4ec4ce12998a1dfc490b601658b93de49671b2f66f264f81a13L2-R8) [[2]](diffhunk://#diff-cffeae69f692d4ec4ce12998a1dfc490b601658b93de49671b2f66f264f81a13L21-R24)

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L12-R29): Modified job names, updated the cibuildwheel version to 2.22.0, and added architecture-specific configurations for different operating systems. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L12-R29) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L37-R47) [[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L71-R77)

* [`.github/workflows/test_build.yml`](diffhunk://#diff-bf8768d943e1d13489fbc7fc04a54c61b19d6d069aeeb86325aa301a89ea378cL19-R33): Updated the job configuration to include architecture-specific settings and updated the cibuildwheel version to 2.22.0. [[1]](diffhunk://#diff-bf8768d943e1d13489fbc7fc04a54c61b19d6d069aeeb86325aa301a89ea378cL19-R33) [[2]](diffhunk://#diff-bf8768d943e1d13489fbc7fc04a54c61b19d6d069aeeb86325aa301a89ea378cL41-R47)

* [`.github/workflows/test_linux.yml`](diffhunk://#diff-50268fc35d89981af92f471612474bb7c59d6a75d0c722e765526afaa15a4410L11-R46): Added architecture-specific settings, updated the checkout and setup-python actions to the latest versions, and updated the Python version to 3.12.

* [`.github/workflows/test_macos.yml`](diffhunk://#diff-ddc3b20a7fabc48e752d6638ff143822ce8dd1128be38b24a82e1f65f802500fL11-R43): Added architecture-specific settings, updated the checkout and setup-python actions to the latest versions, and updated the Python version to 3.12.

* [`.github/workflows/test_windows.yml`](diffhunk://#diff-1012cbb8db2b86be8c8d6a3932c7314678740482fcdf922af3f4040d8fbede4aL14-R29): Updated the checkout and setup-python actions to the latest versions, and updated the Python version to 3.12.